### PR TITLE
use 24h format for releaseDirname instead of 12h

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ You can manipulate the repository using git command, the API is describe in [gif
 
 Attached during `deploy:update` and `rollback:init` task.
 
-The current release dirname of the project, the format used is "yyyymmddhhMMss" (grunt.template.date format).
+The current release dirname of the project, the format used is "yyyymmddHHMMss" (grunt.template.date format).
 
 #### shipit.releasesPath
 

--- a/tasks/deploy/update.js
+++ b/tasks/deploy/update.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
      */
 
     function createReleasePath(cb) {
-      grunt.shipit.releaseDirname = grunt.template.date('yyyymmddhhMMss');
+      grunt.shipit.releaseDirname = grunt.template.date('yyyymmddHHMMss');
       grunt.shipit.releasesPath = path.join(grunt.shipit.config.deployTo, 'releases');
       grunt.shipit.releasePath = path.join(grunt.shipit.releasesPath, grunt.shipit.releaseDirname);
 

--- a/test/unit/tasks/deploy/update.js
+++ b/test/unit/tasks/deploy/update.js
@@ -38,7 +38,7 @@ describe('deploy:update task', function () {
   it('should create release path, and do a remote copy', function (done) {
     runTask('deploy:update', function (err) {
       if (err) return done(err);
-      var dirName = grunt.template.date('yyyymmddhhMMss');
+      var dirName = grunt.template.date('yyyymmddHHMMss');
       expect(shipit.releaseDirname).to.equal(dirName);
       expect(shipit.releasesPath).to.equal('/remote/deploy/releases');
       expect(shipit.releasePath).to.equal('/remote/deploy/releases/' + dirName);


### PR DESCRIPTION
that is what was used previously, when 'moment' was used for date
formatting. 12h format causes terrible consequences:

(1) every timestamp repeats twice a day, for AM and PM. Which is bad
because deploy:cleanup task makes sorted list of directories, and
removes oldest, which might actually happen to be the directory which
was just released.

(2) if your project haven't specified exact version of grunt-shipit in
package.json, and multiple people are deploying from different
workspaces, one might be using 0.4.2 (12h) the other 0.4.0 (24h) and
then the cleanup of your current dir will hit you for sure.
