### PR TITLE
Remove default reference to port 22.

### DIFF
--- a/lib/ssh/connection-pool.js
+++ b/lib/ssh/connection-pool.js
@@ -26,14 +26,13 @@ function ConnectionPool(connections, options) {
     if (connection instanceof Connection) return connection;
 
     var splitURL = connection.split(':');
-    var port = 22;
 
     if (splitURL[1]) {
       connection = splitURL[0];
-      port = splitURL[1];
+      options = extend(options || {}, {port: splitURL[1]});
+    } else {
+      options = extend(options || {});
     }
-
-    options = extend(options || {}, {port: port});
     return new Connection(extend({remote: connection}, options));
   });
 

--- a/lib/ssh/connection.js
+++ b/lib/ssh/connection.js
@@ -151,7 +151,9 @@ function formatExcludes(excludes) {
 
 function buildSSHArgs(options) {
     var args = [];
-    args.push('-p ' + (options.port || 22));
+    if (options.port) {
+      args.push('-p ' + options.port);
+    }
     if (options.key) {
       args.push('-i ' + options.key);
     }

--- a/test/unit/ssh/connection.js
+++ b/test/unit/ssh/connection.js
@@ -57,7 +57,7 @@ describe('SSH Connection', function () {
       connection.run('my-command -x', {cwd: '/root'}, done);
 
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -p 22 user@host "my-command -x"',
+        'ssh user@host "my-command -x"',
         {cwd: '/root', maxBuffer: 1000 * 1024}
       );
     });
@@ -66,7 +66,7 @@ describe('SSH Connection', function () {
       connection.run('echo "ok"', {cwd: '/root'}, done);
 
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -p 22 user@host "echo \\"ok\\""',
+        'ssh user@host "echo \\"ok\\""',
         {cwd: '/root', maxBuffer: 1000 * 1024}
       );
     });
@@ -84,7 +84,7 @@ describe('SSH Connection', function () {
       connection.run('sudo my-command -x', {cwd: '/root'}, done);
 
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -tt -p 22 user@host "sudo my-command -x"',
+        'ssh -tt user@host "sudo my-command -x"',
         {cwd: '/root', maxBuffer: 1000 * 1024}
       );
     });
@@ -94,11 +94,11 @@ describe('SSH Connection', function () {
       connection.run('my-command2 -x', function () {});
 
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -p 22 user@host "my-command -x"'
+        'ssh user@host "my-command -x"'
       );
 
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -p 22 user@host "my-command2 -x"'
+        'ssh user@host "my-command2 -x"'
       );
     });
 
@@ -110,7 +110,32 @@ describe('SSH Connection', function () {
       });
       connection.run('my-command -x', function () {});
       expect(childProcess.exec).to.be.calledWith(
-        'ssh -p 22 -i /path/to/key user@host "my-command -x"'
+        'ssh -i /path/to/key user@host "my-command -x"'
+      );
+    });
+
+    it('should use port if present', function () {
+      connection = new Connection({
+        remote: 'user@host',
+        logger: logger,
+        port: '12345'
+      });
+      connection.run('my-command -x', function () {});
+      expect(childProcess.exec).to.be.calledWith(
+        'ssh -p 12345 user@host "my-command -x"'
+      );
+    });
+
+    it('should use port and key if both are present', function () {
+      connection = new Connection({
+        remote: 'user@host',
+        logger: logger,
+        port: '12345',
+        key: '/path/to/key'
+      });
+      connection.run('my-command -x', function () {});
+      expect(childProcess.exec).to.be.calledWith(
+        'ssh -p 12345 -i /path/to/key user@host "my-command -x"'
       );
     });
   });
@@ -128,14 +153,14 @@ describe('SSH Connection', function () {
     it('should call cmd.spawn', function (done) {
       connection.copy('/src/dir', '/dest/dir', done);
 
-      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -p 22" /src/dir user@host:/dest/dir');
+      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh " /src/dir user@host:/dest/dir');
     });
 
     it('should accept "ignores" option', function (done) {
       connection.copy('/src/dir', '/dest/dir', {ignores: ['a', 'b']}, done);
 
       expect(childProcess.exec).to.be.calledWith('rsync --exclude a --exclude b -az -e ' +
-        '"ssh -p 22" /src/dir user@host:/dest/dir');
+        '"ssh " /src/dir user@host:/dest/dir');
     });
 
     it('should use key if present', function (done) {
@@ -145,7 +170,28 @@ describe('SSH Connection', function () {
         key: '/path/to/key'
       });
       connection.copy('/src/dir', '/dest/dir', done);
-      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -p 22 -i /path/to/key" /src/dir user@host:/dest/dir');
+      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -i /path/to/key" /src/dir user@host:/dest/dir');
+    });
+
+    it('should use port if present', function (done) {
+      connection = new Connection({
+        remote: 'user@host',
+        logger: logger,
+        port: '12345'
+      });
+      connection.copy('/src/dir', '/dest/dir', done);
+      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -p 12345" /src/dir user@host:/dest/dir');
+    });
+
+    it('should use port and key if both are present', function (done) {
+      connection = new Connection({
+        remote: 'user@host',
+        logger: logger,
+        port: '12345',
+        key: '/path/to/key'
+      });
+      connection.copy('/src/dir', '/dest/dir', done);
+      expect(childProcess.exec).to.be.calledWith('rsync -az -e "ssh -p 12345 -i /path/to/key" /src/dir user@host:/dest/dir');
     });
 
   });


### PR DESCRIPTION
Default reference to port 22 when one is not specified breaks default configuration in .ssh/config. This change removes the default refernce and uses the '-p' switch only when the port is explicitly specified. Otherwise the ssh command will fallback to default settings in .ssh/config or to port 22 when there is no local configuration for given hostname.
